### PR TITLE
Fix broken example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 #Examples
-example.txt
-example.js
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -23,15 +23,17 @@ Then hit autoupdate to update the app.
 And our script, `example.js`, looks as follows:
 
 ```javascript
-var vfile = require('to-vfile');
-var report = require('vfile-reporter');
-var retext = require('retext');
-var googlestyleguide = require('retext-google-styleguide');
+import {retext} from 'retext'
+import googlestyleguide from 'retext-google-styleguide';
+//import {readSync} from 'to-vfile'
+import pkg from 'to-vfile'
+const {readSync} = pkg;
+import {reporter} from 'vfile-reporter'
 
 retext()
   .use(googlestyleguide)
-  .process(vfile.readSync('example.txt'), function (err, file) {
-    console.error(report(err || file));
+  .process(readSync('example.txt'), function (err, file) {
+    console.error(reporter(err || file));
   });
 ```
 

--- a/example/example.js
+++ b/example/example.js
@@ -1,0 +1,17 @@
+import {retext} from 'retext'
+import googlestyleguide from 'retext-google-styleguide';
+//import {readSync} from 'to-vfile'
+import pkg from 'to-vfile'
+const {readSync} = pkg;
+
+import {reporter} from 'vfile-reporter'
+// var vfile = require('to-vfile');
+// var report = require('vfile-reporter');
+// var retext = require('retext');
+// var googlestyleguide = require('retext-google-styleguide');
+
+retext()
+  .use(googlestyleguide)
+  .process(readSync('example.txt'), function (err, file) {
+    console.error(reporter(err || file));
+  });

--- a/example/example.js
+++ b/example/example.js
@@ -1,14 +1,8 @@
 import {retext} from 'retext'
 import googlestyleguide from 'retext-google-styleguide';
-//import {readSync} from 'to-vfile'
 import pkg from 'to-vfile'
 const {readSync} = pkg;
-
 import {reporter} from 'vfile-reporter'
-// var vfile = require('to-vfile');
-// var report = require('vfile-reporter');
-// var retext = require('retext');
-// var googlestyleguide = require('retext-google-styleguide');
 
 retext()
   .use(googlestyleguide)

--- a/example/example.txt
+++ b/example/example.txt
@@ -1,0 +1,2 @@
+For 3-D rotation, abort the app first.
+Then hit autoupdate to update the app.

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,22 @@
+{
+  "type": "module",
+  "name": "retext-example",
+  "version": "1.0.0",
+  "main": "example.js",
+  "dependencies": {
+    "retext": "^8.1.0",
+    "retext-emoji": "^8.1.0",
+    "retext-google-styleguide": "^1.0.0",
+    "retext-profanities": "^7.2.1",
+    "to-vfile": "3.0.0",
+    "vfile-reporter": "^7.0.4"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}


### PR DESCRIPTION
Hello @gaurav-nelson, I found this amazing repository while searching for a linter that enforces `google developer documentation style`. However, I noticed that the example on README.md is not up to date with latest npm packages. 

I fixed README.md and add a directory called `example` that contains `example.txt`, `example.js` and `package.json`. 

Thank you again!